### PR TITLE
Add counter for total number of cards and estimate for the generated file size

### DIFF
--- a/css/vkit.css
+++ b/css/vkit.css
@@ -211,6 +211,11 @@
     margin-top: 1em;
 }
 
+.vkit-card-list-info {
+    font-weight: bold;
+    display: inline-block;
+}
+
 #printProgressObj {
     position:fixed;
     top: 40%; 
@@ -220,16 +225,6 @@
     background-color: #DADADA; 
     border:thin solid black;
     display:none
-}
-
-#vkit-total-num-cards {
-    font-weight: bold;
-    display: inline-block;
-}
-
-#vkit-unique-num-cards {
-    font-weight: bold;
-    display: inline-block;
 }
 
 fieldset {

--- a/css/vkit.css
+++ b/css/vkit.css
@@ -222,6 +222,16 @@
     display:none
 }
 
+#vkit-total-num-cards {
+    font-weight: bold;
+    display: inline-block;
+}
+
+#vkit-unique-num-cards {
+    font-weight: bold;
+    display: inline-block;
+}
+
 fieldset {
     border:thin solid rgb(255, 167, 74);
 }

--- a/index.html
+++ b/index.html
@@ -75,9 +75,9 @@
         <div class="vkit-button-column">
         </div>
         <div class="vkit-column">
-            Total number of selected cards: <div id="vkit-total-num-cards">0</div>
+            Total number of selected cards: <div id="vkit-total-num-cards" class="vkit-card-list-info">0</div>
             <br />
-            Number of unique selected cards: <div id="vkit-unique-num-cards">0</div>
+            Estimated file size: <div id="vkit-size-estimate" class="vkit-card-list-info">0 MB</div>
         </div>
     </div>
     

--- a/index.html
+++ b/index.html
@@ -75,6 +75,9 @@
         <div class="vkit-button-column">
         </div>
         <div class="vkit-column">
+            Total number of selected cards: <div id="vkit-total-num-cards">0</div>
+            <br />
+            Number of unique selected cards: <div id="vkit-unique-num-cards">0</div>
         </div>
     </div>
     

--- a/js/VkitMain.js
+++ b/js/VkitMain.js
@@ -167,6 +167,7 @@ function addSelectedCards(isWhiteBorder) {
 			
 	});
 
+	updateCardNumbers();
 }
 
 function redrawSelectedCards() {
@@ -190,9 +191,18 @@ function removeSelectedCards() {
 			}
 		}
 	});
+
+	updateCardNumbers();
 }
 
-var TO_RADIANS = Math.PI/180; 
+function updateCardNumbers() {
+	const totalNum = cardsForPdf.length;
+	const uniqueNum = new Set(cardsForPdf).size;
+	document.getElementById('vkit-total-num-cards').innerHTML = totalNum;
+	document.getElementById('vkit-unique-num-cards').innerHTML = uniqueNum;
+}
+
+var TO_RADIANS = Math.PI / 180;
 
 function convertImgToBase64(isWhiteBorder, url, canvas, img, callback) {
 

--- a/js/VkitMain.js
+++ b/js/VkitMain.js
@@ -20,6 +20,7 @@ var spacingOptions = {
 var matchingCards = [];
 var cardsForPdf = [];
 var printedCards = [];
+var cardQuality = 'double';
 
 console.log("Vkit Verison 1.2");
 
@@ -167,7 +168,7 @@ function addSelectedCards(isWhiteBorder) {
 			
 	});
 
-	updateCardNumbers();
+	updateCardNumbersAndSizeEstimate();
 }
 
 function redrawSelectedCards() {
@@ -192,14 +193,62 @@ function removeSelectedCards() {
 		}
 	});
 
-	updateCardNumbers();
+	updateCardNumbersAndSizeEstimate();
 }
 
-function updateCardNumbers() {
-	const totalNum = cardsForPdf.length;
-	const uniqueNum = new Set(cardsForPdf).size;
-	document.getElementById('vkit-total-num-cards').innerHTML = totalNum;
-	document.getElementById('vkit-unique-num-cards').innerHTML = uniqueNum;
+function updateCardNumbersAndSizeEstimate() {
+	const totalCardsNum = cardsForPdf.length;
+	document.getElementById('vkit-total-num-cards').innerHTML = totalCardsNum;
+	const distinctCardsNum = new Set(cardsForPdf).size;
+	const sizeEstimatePerDistinctCardInBytes = getCardSizeEstimateInBytes(cardQuality);
+	const sizeEstimateBytes = sizeEstimatePerDistinctCardInBytes * distinctCardsNum;
+	const sizeEstimatePrintable = getHumanReadableFileSize(sizeEstimateBytes);
+	document.getElementById('vkit-size-estimate').innerHTML = sizeEstimatePrintable;
+}
+
+// Receives the quality the user selected as a string
+// Expected values: 'huge', 'double' or 'original'
+function getCardSizeEstimateInBytes(cardQuality) {
+	switch (cardQuality) {
+		case 'original': return 670_000; // 670 KB
+		case 'double': return 2_700_000; // 2.7 MB
+		case 'huge': return 10_800_000; // 10.8 MB
+		default: alert('Unexpected cardQuality value in getCardSizeEstimateInBytes ' + cardQuality); return -1;
+	}
+}
+
+/**
+ * From https://stackoverflow.com/a/14919494
+ *
+ * Format bytes as human-readable text.
+ *
+ * @param bytes Number of bytes.
+ * @param si True to use metric (SI) units, aka powers of 1000. False to use
+ *           binary (IEC), aka powers of 1024.
+ * @param dp Number of decimal places to display.
+ *
+ * @return Formatted string.
+ */
+function getHumanReadableFileSize(bytes, si = false, dp = 1) {
+	const thresh = si ? 1000 : 1024;
+
+	if (Math.abs(bytes) < thresh) {
+		return bytes + ' B';
+	}
+
+	const units = si
+		? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+		: ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+	let u = -1;
+	const r = 10 ** dp;
+
+	do {
+		bytes /= thresh;
+		++u;
+	} while (Math.round(Math.abs(bytes) * r) / r >= thresh && u < units.length - 1);
+
+
+	return bytes.toFixed(dp) + ' ' + units[u];
 }
 
 var TO_RADIANS = Math.PI / 180;
@@ -448,9 +497,8 @@ function generateZippedPNG() {
 
 		} else {
 
-			var size = $('input[name=size]:checked', '#sizeForm').val();
 			var cardName = cardsForPdf[currentCardIndex];
-			var cardPath = allCardNames[cardName][size];
+			var cardPath = allCardNames[cardName][cardQuality];
 			console.log("image: " + cardPath );
 
 			// Async function to keep adding new cards until finished
@@ -518,9 +566,8 @@ function generatePdf() {
 
 			} else {
 
-				var size = $('input[name=size]:checked', '#sizeForm').val();
 				var cardName = cardsForPdf[currentCardIndex];
-				var cardPath = allCardNames[cardName][size];
+				var cardPath = allCardNames[cardName][cardQuality];
 				console.log("image: " + cardPath );
 
 				// Async function to keep adding new cards until finished
@@ -738,7 +785,11 @@ $(document).ready(function() {
 			$("#bleedForm").show()
 		}
 	});
-	
+
+        $('input[type=radio][name=size]').change(function() {
+                cardQuality = this.value;
+                updateCardNumbersAndSizeEstimate();
+	});
 	
 	jQuery('.numbersOnly').on("input", function () { 
 		this.value = this.value.replace(/[^0-9.]/g, '').replace(/(\..*?)\..*/g, '$1');


### PR DESCRIPTION
This PR adds a counter for the total number of cards, as well as an estimate of the size of the file the user will download. Everytime cards get added or removed from the selection, the numbers are calculated completely anew (this isn't very performant, at least for the unique counter, but I doubt people will add more than ~1k-10k cards and should work at those sizes).

Looks like this (both commits):
![image](https://github.com/PlayersCouncil/lotr-vkit/assets/5873110/65a693e8-35d7-4f3f-abf3-6aea0db07f04)
(first commit only)
![image](https://github.com/PlayersCouncil/lotr-vkit/assets/5873110/36336d18-55df-4a11-b97e-b29b67b95028)

Tested manually by adding and removing some cards and checking that the counter and estimate works. For the estimate, generating a PDF with 1 card and just multiplying that size by the number of distinct cards seemed a very exact way to estimate, and roughly matches the estimates given on the site already. I did not test PNG generation.